### PR TITLE
Fix `object java.lang.Object in compiler mirror not found` by using the

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bazel-*
+.ijwb/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,8 @@
 workspace(name = "scala_example")
 
-rules_scala_version="7522c866450cf7810eda443e91ff44d2a2286ba1" # update this as needed
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+rules_scala_version="a89d44f7ef67d93dedfc9888630f48d7723516f7" # update this as needed
 
 http_archive(
     name = "io_bazel_rules_scala",

--- a/intellij.bazelproject
+++ b/intellij.bazelproject
@@ -1,0 +1,29 @@
+directories:
+  # Add the directories you want added as source here
+  # By default, we've added your entire workspace ('.')
+  .
+
+targets:
+  # Add targets that reach the source code that you want to resolve here
+  # By default, we've added all targets in your workspace
+  //...
+
+  # also explictly name targets so Run configurations will be generated for them
+  //example-bin:example-bin
+  //example-lib:test
+
+
+
+additional_languages:
+  # Uncomment any additional languages you want supported
+  # android
+  # dart
+  # go
+  # javascript
+  # kotlin
+  # scala
+  # typescript
+  scala
+
+test_sources:
+  example-lib/test/*

--- a/tools/build_rules/prelude_bazel
+++ b/tools/build_rules/prelude_bazel
@@ -1,1 +1,2 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_macro_library","scala_binary", "scala_test")
+load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")


### PR DESCRIPTION
latest version of scala_rules see https://github.com/bazelbuild/rules_scala/issues/591

Fix `The native http_archive rule is deprecated` introduced in bazel
0.20.0 by loading http.bzl see https://github.com/alexeagle/angular-bazel-example/issues/255

Fixes #8 