### PR TITLE
Fix `name 'scala_import' is not defined` 

### DIFF
--- a/tools/build_rules/prelude_bazel
+++ b/tools/build_rules/prelude_bazel
@@ -1,1 +1,2 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_macro_library","scala_binary", "scala_test")
+load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")


### PR DESCRIPTION
by loading scala_import.bzl in the prelude